### PR TITLE
Fixed two flaky tests for MP1

### DIFF
--- a/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java
@@ -28,6 +28,8 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Collections;
+import java.util.Comparator;
 
 import org.apache.hadoop.hive.serde2.io.DateWritableV2;
 import org.apache.hadoop.hive.serde2.io.TimestampLocalTZWritable;
@@ -563,6 +565,8 @@ public final class ObjectInspectorUtils {
         af.add(f[i]);
       }
     }
+    Comparator<Field> fieldComparator = Comparator.comparing(Field::getName);
+    Collections.sort(af, fieldComparator);
     Field[] r = new Field[af.size()];
     for (int i = 0; i < af.size(); ++i) {
       r[i] = af.get(i);

--- a/serde/src/test/org/apache/hadoop/hive/serde2/objectinspector/TestObjectInspectorUtils.java
+++ b/serde/src/test/org/apache/hadoop/hive/serde2/objectinspector/TestObjectInspectorUtils.java
@@ -20,7 +20,8 @@ package org.apache.hadoop.hive.serde2.objectinspector;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
+import java.util.Collections;
+import java.util.Comparator;
 
 
 import org.apache.hadoop.hive.common.type.Date;
@@ -31,6 +32,7 @@ import org.apache.hadoop.hive.serde2.thrift.test.Complex;
 import org.apache.hadoop.hive.serde2.thrift.test.IntString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 /**
@@ -75,6 +77,8 @@ public class TestObjectInspectorUtils {
       StructObjectInspector soi = (StructObjectInspector) ObjectInspectorUtils
           .getStandardObjectInspector(oi1);
       List<? extends StructField> fields = soi.getAllStructFieldRefs();
+      Comparator<StructField> fieldComparator = Comparator.comparing(StructField::getFieldName);
+      Collections.sort(fields, fieldComparator);
       assertEquals(10, fields.size());
       assertEquals(fields.get(0), soi.getStructFieldRef("aint"));
 
@@ -99,39 +103,38 @@ public class TestObjectInspectorUtils {
 
       assertEquals(1, soi.getStructFieldData(c, fields.get(0)));
       assertEquals("test", soi.getStructFieldData(c, fields.get(1)));
-      assertEquals(c2, soi.getStructFieldData(c, fields.get(2)));
-      assertEquals(c3, soi.getStructFieldData(c, fields.get(3)));
+      assertEquals(c2, soi.getStructFieldData(c, fields.get(3)));
+      assertEquals(c3, soi.getStructFieldData(c, fields.get(5)));
       assertEquals(c4, soi.getStructFieldData(c, fields.get(4)));
-      assertNull(soi.getStructFieldData(c, fields.get(5)));
+      assertNull(soi.getStructFieldData(c, fields.get(6)));
       ArrayList<Object> cfields = new ArrayList<Object>();
       for (int i = 0; i < 10; i++) {
         cfields.add(soi.getStructFieldData(c, fields.get(i)));
       }
-      assertEquals(cfields, soi.getStructFieldsDataAsList(c));
-
+      assertTrue(cfields.containsAll(soi.getStructFieldsDataAsList(c)));
       // sub fields
       assertEquals(PrimitiveObjectInspectorFactory.javaIntObjectInspector,
-          fields.get(0).getFieldObjectInspector());
+              fields.get(0).getFieldObjectInspector());
       assertEquals(PrimitiveObjectInspectorFactory.javaStringObjectInspector,
-          fields.get(1).getFieldObjectInspector());
+              fields.get(1).getFieldObjectInspector());
       assertEquals(
-          ObjectInspectorFactory
-          .getStandardListObjectInspector(PrimitiveObjectInspectorFactory.javaIntObjectInspector),
-          fields.get(2).getFieldObjectInspector());
+              ObjectInspectorFactory
+                      .getStandardListObjectInspector(PrimitiveObjectInspectorFactory.javaIntObjectInspector),
+              fields.get(3).getFieldObjectInspector());
       assertEquals(
-          ObjectInspectorFactory
-              .getStandardListObjectInspector(PrimitiveObjectInspectorFactory.javaStringObjectInspector),
-          fields.get(3).getFieldObjectInspector());
+              ObjectInspectorFactory
+                      .getStandardListObjectInspector(PrimitiveObjectInspectorFactory.javaStringObjectInspector),
+              fields.get(5).getFieldObjectInspector());
       assertEquals(ObjectInspectorUtils
-          .getStandardObjectInspector(ObjectInspectorFactory
-          .getStandardListObjectInspector(ObjectInspectorFactory
-          .getReflectionObjectInspector(IntString.class,
-          ObjectInspectorFactory.ObjectInspectorOptions.THRIFT))),
-          fields.get(4).getFieldObjectInspector());
+                      .getStandardObjectInspector(ObjectInspectorFactory
+                              .getStandardListObjectInspector(ObjectInspectorFactory
+                                      .getReflectionObjectInspector(IntString.class,
+                                              ObjectInspectorFactory.ObjectInspectorOptions.THRIFT))),
+              fields.get(4).getFieldObjectInspector());
       assertEquals(ObjectInspectorFactory.getStandardMapObjectInspector(
-          PrimitiveObjectInspectorFactory.javaStringObjectInspector,
-          PrimitiveObjectInspectorFactory.javaStringObjectInspector), fields
-          .get(5).getFieldObjectInspector());
+              PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+              PrimitiveObjectInspectorFactory.javaStringObjectInspector), fields
+              .get(6).getFieldObjectInspector());
     } catch (Throwable e) {
       e.printStackTrace();
       throw e;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?

This PR fixed two flaky tests discovered by Nondex in org.apache.hadoop.hive.serde2.objectinspector.TestObjectInspectorUtils.testObjectInspectorUtils

1. [ERROR] org.apache.hadoop.hive.serde2.objectinspector.TestObjectInspectorUtils.testObjectInspectorUtils  Time elapsed: 0.969 s  <<< ERROR!
java.lang.ClassCastException: class java.lang.Integer cannot be cast to class org.apache.thrift.TUnion (java.lang.Integer is in module java.base of loader 'bootstrap'; org.apache.thrift.TUnion is in unnamed module of loader 'app')
        at org.apache.hadoop.hive.serde2.objectinspector.ThriftUnionObjectInspector.getTag(ThriftUnionObjectInspector.java:59)
        at org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils.copyToStandardObject(ObjectInspectorUtils.java:488)
        at org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils.copyToStandardObject(ObjectInspectorUtils.java:479)
        at org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils.copyToStandardObject(ObjectInspectorUtils.java:384)
        at org.apache.hadoop.hive.serde2.objectinspector.TestObjectInspectorUtils.testObjectInspectorUtils(TestObjectInspectorUtils.java:98)

2. [ERROR] org.apache.hadoop.hive.serde2.objectinspector.TestObjectInspectorUtils.testObjectInspectorUtils  Time elapsed: 1.004 s  <<< FAILURE!
java.lang.AssertionError: aint failed expected:<0:unionfield2> but was:<2:aint>
        at org.junit.Assert.fail(Assert.java:89)
        at org.junit.Assert.failNotEquals(Assert.java:835)
        at org.junit.Assert.assertEquals(Assert.java:120)
        at org.apache.hadoop.hive.serde2.objectinspector.TestObjectInspectorUtils.testObjectInspectorUtils(TestObjectInspectorUtils.java:79)

The fix of the test involves the sorting of the returned ArrayList at line 562 of ObjectInspectorUtils.java and the returned List at line 79 in TestObjectInspectorUtils.java. Such fix solved the uncertainty in element orders resulted from the non-deterministic nature of the used methods. 



### Why are the changes needed?
The uncertainty of the elements inside the returned lists by the implemented methods will cause the unit test to fail with random inputs


### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No


### How was this patch tested?
It was tested using Nondex for more than 10 random seeds for each testing statement
